### PR TITLE
Minor improvements

### DIFF
--- a/src/generator/config.rs
+++ b/src/generator/config.rs
@@ -1,5 +1,5 @@
-const DEFAULT_UNICODE_DATA_PATH:&str = "UnicodeData.txt";
-const DEFAULT_TEMPLATE_PATH:&str = "template.uc";
+const DEFAULT_UNICODE_DATA_PATH: &str = "UnicodeData.txt";
+const DEFAULT_TEMPLATE_PATH: &str = "template.uc";
 
 pub struct Config {
     pub unicode_data_path: String,
@@ -7,8 +7,7 @@ pub struct Config {
 }
 
 impl Config {
-    pub fn new (arguments: Vec<String>) -> Config {
-
+    pub fn new(arguments: Vec<String>) -> Config {
         Config {
             unicode_data_path: arguments
                 .get(1)

--- a/src/generator/mod.rs
+++ b/src/generator/mod.rs
@@ -110,5 +110,5 @@ pub fn run(config: &Config) {
             .read_mappings(record)
             .expect("Provided Unicode data file has incorrect csv format");
     }
-    generate_uc(config, &mappings).expect("Issues with writing into file \"UnicodeData.uc\"");
+    generate_uc(config, &mappings).expect(r#"Issues with writing into file "UnicodeData.uc""#);
 }

--- a/src/generator/mod.rs
+++ b/src/generator/mod.rs
@@ -102,22 +102,13 @@ fn generate_uc(config: &Config, mappings: &CaseMappings) -> Result<(), Box<dyn E
 }
 
 pub fn run(config: &Config) {
-    let mut data_reader = match get_data_reader(config) {
-        Ok(reader) => reader,
-        Err(_) => panic!("Cannot open file with unicode data"),
-    };
+    let mut data_reader = get_data_reader(config).expect("Cannot open file with unicode data");
     let mut mappings = CaseMappings::new();
     for result in data_reader.records() {
-        let record;
-        match result {
-            Ok(parsed_record) => record = parsed_record,
-            Err(_) => panic!("Provided Unicode data file has incorrect csv format"),
-        }
-        if let Err(_) = mappings.read_mappings(record) {
-            panic!("Provided Unicode data file has incorrect csv format");
-        }
+        let record = result.expect("Provided Unicode data file has incorrect csv format");
+        mappings
+            .read_mappings(record)
+            .expect("Provided Unicode data file has incorrect csv format");
     }
-    if let Err(_) = generate_uc(config, &mappings) {
-        panic!("Issues with writing into file \"UnicodeData.uc\"");
-    }
+    generate_uc(config, &mappings).expect("Issues with writing into file \"UnicodeData.uc\"");
 }


### PR DESCRIPTION
1. Run "cargo fmt" to use default formatting, which used in majority of Rust codebases.
2. Replace match+panic with expect() call, which does the same thing: https://doc.rust-lang.org/std/result/enum.Result.html#method.expect
3. Use raw string literal (https://doc.rust-lang.org/rust-by-example/std/str.html) to simplify string by removing escaped quotes.